### PR TITLE
fix: オンゲキNET反映前曲をプレイした場合に全曲取得/履歴取得の切り替えが上手く働かない問題を修正

### DIFF
--- a/OngekiScoreLog/resources/assets/js/bookmarklets/getScore.ts
+++ b/OngekiScoreLog/resources/assets/js/bookmarklets/getScore.ts
@@ -227,9 +227,16 @@ import * as qs from 'qs';
             }
             var parseHTML = $.parseHTML(html);
             var $innerContainer3 = $(parseHTML).find(".container3").children(".m_10")
-            // もっとも古い履歴の更新日時が最終更新日時以降なら全曲取得に変更
-            let recentUpdate = new Date($innerContainer3.last().find("span.f_r.h_10").text());
-            if (recentUpdate > timestamp) {
+            // 履歴があるなら履歴参照。なければ全曲取得
+            if ($innerContainer3.length > 0) {
+                // もっとも古い履歴の更新日時が最終更新日時以降なら全曲取得に変更
+                let recentUpdate = new Date($innerContainer3.last().find("span.f_r.h_10").text());
+                if (recentUpdate > timestamp) {
+                    this.songToUpload = [];
+                    return;
+                }
+            } else {
+                // オンゲキnetに登録されてない曲50連奏したら引っかかる。
                 this.songToUpload = [];
                 return;
             }

--- a/OngekiScoreLog/resources/assets/js/bookmarklets/getScore.ts
+++ b/OngekiScoreLog/resources/assets/js/bookmarklets/getScore.ts
@@ -227,14 +227,13 @@ import * as qs from 'qs';
             }
             var parseHTML = $.parseHTML(html);
             var $innerContainer3 = $(parseHTML).find(".container3").children(".m_10")
-            // 50曲存在するなら50曲目をとって、更新日時が最終更新日時以降なら全曲取得に変更
-            if ($innerContainer3.length === 50) {
-                let recentUpdate = new Date($innerContainer3.last().find("span.f_r.h_10").text());
-                if (recentUpdate > timestamp) {
-                    this.songToUpload = [];
-                    return;
-                }
+            // もっとも古い履歴の更新日時が最終更新日時以降なら全曲取得に変更
+            let recentUpdate = new Date($innerContainer3.last().find("span.f_r.h_10").text());
+            if (recentUpdate > timestamp) {
+                this.songToUpload = [];
+                return;
             }
+
             $innerContainer3.each((key, value) => {
                 if ($(value).hasClass("m_10")){
                     if (new Date($(value).find("span.f_r.h_10").text()) > timestamp) {

--- a/OngekiScoreLog/resources/assets/js/bookmarklets/getScore.ts
+++ b/OngekiScoreLog/resources/assets/js/bookmarklets/getScore.ts
@@ -236,7 +236,7 @@ import * as qs from 'qs';
                     return;
                 }
             } else {
-                // オンゲキnetに登録されてない曲50連奏したら引っかかる。
+                // 50連続でオンゲキnetに登録されていない曲をプレイすると履歴が空になり、全曲取得が必要になる。
                 this.songToUpload = [];
                 return;
             }


### PR DESCRIPTION
## 内容
オンゲキNETにまだ反映されていない曲をプレイした場合その分の履歴が記録されず、結果として履歴件数が50件を下回り、オンゲキの新規ユーザー向けに設定していた履歴件数=50の条件を突破できなかったことで50曲以上プレイしているのにもかかわらず全曲取得が行われない現象を修正。
## 実装概要
履歴件数=50の条件を削除
## 結果
上記不具合の修正
## これによって起こる可能性のある現象
初めてスコアログにスコアを登録する履歴件数50曲未満のユーザーが登録を行う場合、履歴取得ではなく全件取得が実行される。