### PR TITLE
プライベートモードの実装

### DIFF
--- a/OngekiScoreLog/app/Http/Controllers/Auth/RegisterController.php
+++ b/OngekiScoreLog/app/Http/Controllers/Auth/RegisterController.php
@@ -67,7 +67,7 @@ class RegisterController extends Controller
             'name' => $data['name'],
             'email' => $data['email'],
             'password' => Hash::make($data['password']),
-            'private' => ($data['private'] ? 1 : 0),
+            'private' => (isset($data['private']) && $data['private'] ? 1 : 0),
         ]);
     }
 }

--- a/OngekiScoreLog/app/Http/Controllers/Auth/RegisterController.php
+++ b/OngekiScoreLog/app/Http/Controllers/Auth/RegisterController.php
@@ -67,6 +67,7 @@ class RegisterController extends Controller
             'name' => $data['name'],
             'email' => $data['email'],
             'password' => Hash::make($data['password']),
+            'private' => ($data['private'] ? 1 : 0),
         ]);
     }
 }

--- a/OngekiScoreLog/app/Http/Controllers/SettingController.php
+++ b/OngekiScoreLog/app/Http/Controllers/SettingController.php
@@ -21,21 +21,36 @@ class SettingController extends Controller
             return view('require');
         }
 
-        $external = new ExternalServiceCoordination();
-        $ret = $external->get($user->id);
-
         $display = [];
-        if(count($ret) === 0){
-            $display['screenName'] = "認証していません";
-        }else{
-            $twitter = $external->getTwitter($ret[0]->twitter_access_token, $ret[0]->twitter_access_token_secret);
-            if(is_null($twitter)){
-                $display['screenName'] = "認証していません";
-            }else{
-                $display['screenName'] = $twitter->screen_name;
-            }
-        }
+        $display['private'] = $user->private;
+
         return view('setting', compact('display'));
+    }
+
+    public function getSettingPrivate(){
+        $user = \Auth::user();
+
+        if($user == null){
+            return view('require');
+        }
+
+        $user->private = 1;
+        $user->save();
+
+        return redirect("/setting");
+    }
+
+    public function getSettingPublic(){
+        $user = \Auth::user();
+
+        if($user == null){
+            return view('require');
+        }
+
+        $user->private = 0;
+        $user->save();
+
+        return redirect("/setting");
     }
 
     public function getTwitterAuthentication(){

--- a/OngekiScoreLog/app/Http/Controllers/ViewMusicStatisticsController.php
+++ b/OngekiScoreLog/app/Http/Controllers/ViewMusicStatisticsController.php
@@ -47,7 +47,7 @@ class ViewMusicStatisticsController extends Controller
         $isExist->normal = !is_null($musicData->normal_added_version);
         $isExist->lunatic = !is_null($musicData->lunatic_added_version);
 
-        $users = (new UserStatus)->getRecentAllUserData();
+        $users = (new UserStatus)->getRecentAllUserData(false);
         $users = array_column($users, null, 'user_id');
 
         $statistics = new \stdClass;

--- a/OngekiScoreLog/app/User.php
+++ b/OngekiScoreLog/app/User.php
@@ -17,7 +17,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'password',
+        'name', 'email', 'password', 'private'
     ];
 
     /**

--- a/OngekiScoreLog/app/UserStatus.php
+++ b/OngekiScoreLog/app/UserStatus.php
@@ -14,7 +14,7 @@ class UserStatus extends Model
         $sql = DB::table($this->table)->select('*')
             ->from($this->table)->where('user_id', $id)->orderBy('id', 'desc')->limit(1);
 
-        # ƒvƒ‰ƒCƒx[ƒgƒ†[ƒU‚ğœŠOi©•ª©gˆÈŠOj
+        # ãƒ—ãƒ©ã‚¤ãƒ™ãƒ¼ãƒˆãƒ¦ãƒ¼ã‚¶ã‚’é™¤å¤–ï¼ˆè‡ªåˆ†è‡ªèº«ä»¥å¤–ï¼‰
         if ($exclude_private){
             $me = \Auth::user();
             if ($me === null || $id != $me->id){
@@ -43,7 +43,7 @@ class UserStatus extends Model
                     ->on('t1.created_at', '=', 'latest.latest_created_at');
             });
 
-        # ƒvƒ‰ƒCƒx[ƒgƒ†[ƒU‚ğœŠO
+        # ãƒ—ãƒ©ã‚¤ãƒ™ãƒ¼ãƒˆãƒ¦ãƒ¼ã‚¶ã‚’é™¤å¤–
         if ($exclude_private){
             $sql_all_users = $sql_all_users
                 ->join('users', 't1.user_id', '=', 'users.id')

--- a/OngekiScoreLog/app/UserStatus.php
+++ b/OngekiScoreLog/app/UserStatus.php
@@ -10,14 +10,15 @@ class UserStatus extends Model
     protected $table = "user_status";
     protected $guarded = ['id'];
 
-    function getRecentUserData($id, $exclude_private = true){
+    function getRecentUserData($id, $exclude_private = true)
+    {
         $sql = DB::table($this->table)->select('*')
             ->from($this->table)->where('user_id', $id)->orderBy('id', 'desc')->limit(1);
 
         # プライベートユーザを除外（自分自身以外）
-        if ($exclude_private){
+        if ($exclude_private) {
             $me = \Auth::user();
-            if ($me === null || $id != $me->id){
+            if ($me === null || $id != $me->id) {
                 $sql = $sql
                     ->join('users', "$this->table.user_id", '=', 'users.id')
                     ->where('users.private', 0);
@@ -27,36 +28,39 @@ class UserStatus extends Model
         return $sql->select("$this->table.*")->get();
     }
 
-    function getRecentAllUserData($exclude_private = true){
-        # SELECT * FROM user_status AS t1
-        #     WHERE created_at = (
-        #         SELECT MAX(created_at) FROM user_status AS t2
-        #             WHERE t1.user_id = t2.user_id
-        #     )
-        $sql_latest_status = DB::table("$this->table as t2")
-            ->select('user_id', DB::raw('MAX(created_at) as latest_created_at'))
-            ->groupBy('user_id');
-
-        $sql_all_users = DB::table("$this->table as t1")
-            ->joinSub($sql_latest_status, 'latest', function ($join) {
-                $join->on('t1.user_id', '=', 'latest.user_id')
-                    ->on('t1.created_at', '=', 'latest.latest_created_at');
-            });
-
+    function getRecentAllUserData($exclude_private = true)
+    {
         # プライベートユーザを除外
-        if ($exclude_private){
+        if ($exclude_private) {
+            # SELECT * FROM user_status AS t1
+            #     WHERE created_at = (
+            #         SELECT MAX(created_at) FROM user_status AS t2
+            #             WHERE t1.user_id = t2.user_id
+            #     )
+            $sql_latest_status = DB::table("$this->table as t2")
+                ->select('user_id', DB::raw('MAX(created_at) as latest_created_at'))
+                ->groupBy('user_id');
+
+            $sql_all_users = DB::table("$this->table as t1")
+                ->joinSub($sql_latest_status, 'latest', function ($join) {
+                    $join->on('t1.user_id', '=', 'latest.user_id')
+                        ->on('t1.created_at', '=', 'latest.latest_created_at');
+                });
+
             $sql_all_users = $sql_all_users
                 ->join('users', 't1.user_id', '=', 'users.id')
                 ->where('users.private', 0);
-        }
 
-        $sql = $sql_all_users->select('t1.*')->get();
+            $sql = $sql_all_users->select('t1.*')->get();
+        } else {
+            $sql = DB::select('SELECT * FROM user_status AS t1 WHERE created_at = (SELECT MAX(created_at) FROM user_status AS t2 WHERE t1.user_id = t2.user_id)');
+        }
 
         $users = [];
         foreach ($sql as $key => $value) {
-            if(!in_array($value->user_id, $users)){
+            if (!in_array($value->user_id, $users)) {
                 $users[] = $value->user_id;
-            }else{
+            } else {
                 unset($sql[$key]);
             }
         }

--- a/OngekiScoreLog/app/UserStatus.php
+++ b/OngekiScoreLog/app/UserStatus.php
@@ -8,16 +8,15 @@ use Illuminate\Support\Facades\DB;
 class UserStatus extends Model
 {
     protected $table = "user_status";
-    protected $guarded = ['id'];
 
     function getRecentUserData($id, $exclude_private = true)
     {
         $sql = DB::table($this->table)->select('*')
             ->from($this->table)->where('user_id', $id)->orderBy('id', 'desc')->limit(1);
 
-        # プライベートユーザを除外（自分自身以外）
-        if ($exclude_private) {
-            $me = \Auth::user();
+        $me = \Auth::user();
+        # プライベートユーザを除外（自分自身以外） 管理者権限がある場合は除外しない
+        if ($exclude_private && ($me === null || $me->role !== 7)) {
             if ($me === null || $id != $me->id) {
                 $sql = $sql
                     ->join('users', "$this->table.user_id", '=', 'users.id')

--- a/OngekiScoreLog/app/UserStatus.php
+++ b/OngekiScoreLog/app/UserStatus.php
@@ -10,14 +10,48 @@ class UserStatus extends Model
     protected $table = "user_status";
     protected $guarded = ['id'];
 
-    function getRecentUserData($id){
+    function getRecentUserData($id, $exclude_private = true){
         $sql = DB::table($this->table)->select('*')
             ->from($this->table)->where('user_id', $id)->orderBy('id', 'desc')->limit(1);
-        return $sql->get();
+
+        # プライベートユーザを除外（自分自身以外）
+        if ($exclude_private){
+            $me = \Auth::user();
+            if ($me === null || $id != $me->id){
+                $sql = $sql
+                    ->join('users', "$this->table.user_id", '=', 'users.id')
+                    ->where('users.private', 0);
+            }
+        }
+
+        return $sql->select("$this->table.*")->get();
     }
 
-    function getRecentAllUserData(){
-        $sql = DB::select('SELECT * FROM user_status AS t1 WHERE created_at = (SELECT MAX(created_at) FROM user_status AS t2 WHERE t1.user_id = t2.user_id)');
+    function getRecentAllUserData($exclude_private = true){
+        # SELECT * FROM user_status AS t1
+        #     WHERE created_at = (
+        #         SELECT MAX(created_at) FROM user_status AS t2
+        #             WHERE t1.user_id = t2.user_id
+        #     )
+        $sql_latest_status = DB::table("$this->table as t2")
+            ->select('user_id', DB::raw('MAX(created_at) as latest_created_at'))
+            ->groupBy('user_id');
+
+        $sql_all_users = DB::table("$this->table as t1")
+            ->joinSub($sql_latest_status, 'latest', function ($join) {
+                $join->on('t1.user_id', '=', 'latest.user_id')
+                    ->on('t1.created_at', '=', 'latest.latest_created_at');
+            });
+
+        # プライベートユーザを除外
+        if ($exclude_private){
+            $sql_all_users = $sql_all_users
+                ->join('users', 't1.user_id', '=', 'users.id')
+                ->where('users.private', 0);
+        }
+
+        $sql = $sql_all_users->select('t1.*')->get();
+
         $users = [];
         foreach ($sql as $key => $value) {
             if(!in_array($value->user_id, $users)){

--- a/OngekiScoreLog/database/migrations/2025_08_13_115922_create_private_mode_flag.php
+++ b/OngekiScoreLog/database/migrations/2025_08_13_115922_create_private_mode_flag.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePrivateModeFlag extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->tinyInteger('private')->default(0)->after('role');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('private');
+        });
+    }
+}

--- a/OngekiScoreLog/resources/views/auth/register.blade.php
+++ b/OngekiScoreLog/resources/views/auth/register.blade.php
@@ -58,6 +58,10 @@
                 </div>
             </div>
             <div class="field">
+                <label for="private" class="label">プライベートモード</label>
+                <input id="private" type="checkbox" name="private" autofocus>
+            </div>
+            <div class="field">
                 <div class="control">
                     <button type="submit" class="button is-link">登録</button>
                 </div>

--- a/OngekiScoreLog/resources/views/setting.blade.php
+++ b/OngekiScoreLog/resources/views/setting.blade.php
@@ -6,10 +6,15 @@
 
 @section('content')
     <article class="box">
-        <h3 class="title is-3">Twitter連携</h3>
-        <p>Twitterを連携するとスコア更新を画像とともにツイートできます。<br>
-            認証中のアカウント: {{$display['screenName']}}<br>
-            <a href="/setting/twitter" class="button">連携する</a>
+        <h3 class="title is-3">プライベートモード</h3>
+        <p>プライベートモードにすると他人から見えなくなります。<br>
+            現在の状態: {{$display['private'] ? 'プライベート' : 'パブリック'}}モード<br>
+
+            @if ($display['private'])
+                <a href="/setting/public" class="button">パブリックモードに戻す</a>
+            @else
+                <a href="/setting/private" class="button">プライベートモードにする</a>
+            @endif
         </p>
     </article>
 

--- a/OngekiScoreLog/resources/views/setting.blade.php
+++ b/OngekiScoreLog/resources/views/setting.blade.php
@@ -29,6 +29,11 @@
                 <a href="/setting/private" class="button is-info">プライベートモードを有効にする</a>
             @endif
         </p>
+
+        <h3 class="title is-3">Twitter連携</h3>
+        <p>提供を終了いたしました。</p>
+        <p><a href="#" class="button" disabled>連携する</a></p>
+
     </article>
 
 @endsection

--- a/OngekiScoreLog/resources/views/setting.blade.php
+++ b/OngekiScoreLog/resources/views/setting.blade.php
@@ -7,13 +7,26 @@
 @section('content')
     <article class="box">
         <h3 class="title is-3">プライベートモード</h3>
-        <p>プライベートモードにすると他人から見えなくなります。<br>
-            現在の状態: {{$display['private'] ? 'プライベート' : 'パブリック'}}モード<br>
-
+        <p>
+            プライベートモードにすると自分のユーザーページが他のユーザーから閲覧できなくなります。
+        </p>
+        <p>
+        <ul>
+            <li>・「すべてのユーザー」に表示されなくなります</li>
+            <li>・スコアページやレーティングページ、獲得称号ページが自分以外のユーザーから見えなくなります</li>
+            <li>・副作用として、OngekiScoreLogのデータを利用した外部サイトが利用できなくなるかもしれません</li>
+            <li>※統計情報の集計対象からは外れません</li>
+            <li>※管理者はユーザーサポートのためプライベートモードのユーザーページにアクセスする可能性があります</li>
+        </ul>
+        </p>
+        <p>
+            {{$display['private'] ? '現在の状態: 有効' : ''}}
+        </p>
+        <p>
             @if ($display['private'])
-                <a href="/setting/public" class="button">パブリックモードに戻す</a>
+                <a href="/setting/public" class="button is-danger">プライベートモードを無効にする</a>
             @else
-                <a href="/setting/private" class="button">プライベートモードにする</a>
+                <a href="/setting/private" class="button is-info">プライベートモードを有効にする</a>
             @endif
         </p>
     </article>

--- a/OngekiScoreLog/routes/web.php
+++ b/OngekiScoreLog/routes/web.php
@@ -40,7 +40,9 @@ Route::get('/user', 'ViewAllUserController@getIndex');
 Route::get('/bookmarklet', 'BookmarkletGenerateController@getIndex');
 Route::get('/bookmarklet/agree', 'BookmarkletGenerateController@getBookmarklet');
 Route::get('/setting', 'SettingController@getSetting');
-Route::get('/setting/twitter', 'SettingController@getTwitterAuthentication');
+Route::get('/setting/private', 'SettingController@getSettingPrivate');
+Route::get('/setting/public', 'SettingController@getSettingPublic');
+#Route::get('/setting/twitter', 'SettingController@getTwitterAuthentication');
 
 Route::get('/howto', 'SimpleViewController@getHowto');
 Route::get('/faq', 'SimpleViewController@getFAQ');


### PR DESCRIPTION
他人から情報を見れないようにするプライベートモードを実装しました。
プライベートモードでは以下のようになります。

- 「すべてのユーザー」に表示されない
- ユーザ ID を含む API の内容がログインユーザー自身でなければ見れない

プライベートモードでも統計情報の収集対象にはなります。

プライベートモードにするには以下のようにします。

- 登録時に「プライベートモード」にチェックを入れる
- 設定画面でプライベートモードにする

設定画面を変更する際に Twitter 連携の設定は削除しました。
ただ、一応 setting/twitter API はコメントアウトとし、
getTwitterAuthentication 関数は残してあります。
（$display の設定あたりは削っちゃいましたが……）

身バレを気にしつつ虹レを目指しているらしい某 VTuber を見て
こういう機能があったらいいんじゃないかと思って実装してみました。
