### PR TITLE
fix: プレミアムコース未加入時に更新差分のレート表示がされていた問題の修正

### DIFF
--- a/OngekiScoreLog/app/Http/Controllers/ViewUserProgressController.php
+++ b/OngekiScoreLog/app/Http/Controllers/ViewUserProgressController.php
@@ -9,6 +9,7 @@ use App\UserStatus;
 use App\ScoreData;
 use App\ApplicationVersion;
 use App\ExternalServiceCoordination;
+use App\Facades\OngekiUtility;
 
 class ViewUserProgressController extends Controller
 {
@@ -89,7 +90,12 @@ class ViewUserProgressController extends Controller
                 }
             }
         }
-
+        # レーティングの計算を行うのでプレミアムかどうかの確認をする。
+        $isPremium = false;
+        $targetUser = User::where('id' ,$id)->first();
+        if(\App\UserInformation::IsPremiumPlan($targetUser->id)){
+            $isPremium = true;
+        }
         $score = [
             'new' =>[
                 'Basic' => [
@@ -219,6 +225,11 @@ class ViewUserProgressController extends Controller
                         $progress[$music][$difficulty]["difference"]['over_damage_high_score_rank'] = "不可" . " → " . $value->over_damage_high_score_rank;
                         $progress[$music][$difficulty]["difference"]['is_update_over_damage_high_score_rank'] = "update";
                         $progress[$music][$difficulty]["difference"]['over_damage_high_score'] = "+" . ($value->over_damage_high_score) . "%";
+                        if ($isPremium) {
+                            $newNormalRating = OngekiUtility::RateValueFromTitle($value->title, $value->difficulty, $value->technical_high_score, $value->lampForRating, $value->genre, $value->artist);
+                            $progress[$music][$difficulty]["difference"]['normal_rating'] = "+" . sprintf("%.3f", $newNormalRating);
+                            $progress[$music][$difficulty]["difference"]["new-normal-rating"] = sprintf("%.3f", $newNormalRating);
+                        }
                         $progress[$music][$difficulty]["difference"]['old-lamp-is-fb'] = "not-light";
                         $progress[$music][$difficulty]["difference"]['old-lamp-is-fc'] = "not-light";
                         $progress[$music][$difficulty]["difference"]['old-lamp-is-ab'] = "not-light";
@@ -253,6 +264,11 @@ class ViewUserProgressController extends Controller
                             $progress[$music][$difficulty]["difference"]['over_damage_high_score_rank'] = "N" . " → " . $value->over_damage_high_score_rank;
                             $progress[$music][$difficulty]["difference"]['is_update_over_damage_high_score_rank'] = "update";
                             $progress[$music][$difficulty]["difference"]['over_damage_high_score'] = "+" . ($value->over_damage_high_score) . "%";
+                            if ($isPremium) {
+                                $newNormalRating = OngekiUtility::RateValueFromTitle($value->title, $value->difficulty, $value->technical_high_score, $value->lampForRating, $value->genre, $value->artist);
+                                $progress[$music][$difficulty]["difference"]['normal_rating'] = "+" . sprintf("%.3f", $newNormalRating);
+                                $progress[$music][$difficulty]["difference"]["new-normal-rating"] = sprintf("%.3f", $newNormalRating);
+                            }
                             $progress[$music][$difficulty]["difference"]['old-lamp-is-fb'] = "not-light";
                             $progress[$music][$difficulty]["difference"]['old-lamp-is-fc'] = "not-light";
                             $progress[$music][$difficulty]["difference"]['old-lamp-is-ab'] = "not-light";
@@ -284,6 +300,40 @@ class ViewUserProgressController extends Controller
                                 }
                             }
 
+                            // Rating計算はできるだけ少なくしたいので先に計算しておく。
+                            // ViewUserRatingController.php から引用。
+                            // WARNING: レーティング処理を変えたら変更元も変更する！
+                            if ($isPremium) {
+                                $oldLampForRating = "";
+                                if ($old[$music][$difficulty]->technical_high_score == 1010000){
+                                    if ($old[$music][$difficulty]->full_bell == 1) {
+                                        $oldLampForRating = "FB/AB+";
+                                    } else {
+                                        $oldLampForRating = "AB+";
+                                    }
+                                } elseif ($old[$music][$difficulty]->all_break == 1) {
+                                    if ($old[$music][$difficulty]->full_bell == 1) {
+                                        $oldLampForRating = "FB/AB";
+                                    } else {
+                                        $oldLampForRating = "AB";
+                                    }
+                                } elseif ($old[$music][$difficulty]->full_combo == 1) {
+                                    if ($old[$music][$difficulty]->full_bell == 1) {
+                                        $oldLampForRating = "FB/FC";
+                                    } else {
+                                        $oldLampForRating = "FC";
+                                    }
+                                } else {
+                                    if ($old[$music][$difficulty]->full_bell == 1) {
+                                        $oldLampForRating = "FB";
+                                    }
+                                }
+
+                                $newNormalRating = OngekiUtility::RateValueFromTitle($value->title, $value->difficulty, $value->technical_high_score, $value->lampForRating, $value->genre, $value->artist);
+                                $oldNormalRating = OngekiUtility::RateValueFromTitle($value->title, $old[$music][$difficulty]->difficulty, $old[$music][$difficulty]->technical_high_score, $oldLampForRating, $value->genre, $value->artist);
+                                $progress[$music][$difficulty]["difference"]['normal_rating'] = ($newNormalRating - $oldNormalRating) != 0 ? "+" . sprintf("%.3f",($newNormalRating - $oldNormalRating)) : "";
+                                $progress[$music][$difficulty]["difference"]["new-normal-rating"] = sprintf("%.3f", $newNormalRating);
+                            }
                             $progress[$music][$difficulty]["difference"]['battle_high_score'] = ($value->battle_high_score - $old[$music][$difficulty]->battle_high_score) != 0 ? "+" . number_format($value->battle_high_score - $old[$music][$difficulty]->battle_high_score) : "";
                             $progress[$music][$difficulty]["difference"]['technical_high_score'] = ($value->technical_high_score - $old[$music][$difficulty]->technical_high_score) != 0 ? "+" . number_format($value->technical_high_score - $old[$music][$difficulty]->technical_high_score) : "";
                             $progress[$music][$difficulty]["difference"]['platinum_score'] = ($value->platinum_score - $old[$music][$difficulty]->platinum_score) != 0 ? "+" . number_format($value->platinum_score - $old[$music][$difficulty]->platinum_score) : "";
@@ -355,6 +405,6 @@ class ViewUserProgressController extends Controller
             ]
         ];
 
-        return view('user_progress', compact('filter', 'url', 'status', 'progress', 'date', 'score', 'version', 'display', 'id', 'sidemark', 'isLoggedIn', 'isTwitterEnabled', 'twitterScreenName'));
+        return view('user_progress', compact('filter', 'url', 'status', 'progress', 'date', 'score', 'version', 'display', 'id', 'sidemark', 'isLoggedIn', 'isTwitterEnabled', 'twitterScreenName', 'isPremium'));
     }
 }

--- a/OngekiScoreLog/resources/views/user_progress.blade.php
+++ b/OngekiScoreLog/resources/views/user_progress.blade.php
@@ -164,7 +164,7 @@ $difficulties = ['Total', 'Basic', 'Advanced', 'Expert', 'Master', 'Lunatic'];
                                 <span class="score-title">Platinum Score</span>
                                 <span class="score">{{number_format($value['new']->platinum_score)}}</span>
                                 <span class="difference">{{$value['difference']['platinum_score']}}</span>
-                                {{-- new-normal-ratingが空=該当ユーザーがプレミアムでない 場合そもそもレーティング情報を表示しない --}}
+                                {{-- 該当ユーザーがプレミアムでない場合そもそもレーティング情報を表示しない --}}
                                 @if($isPremium)
                                     <br>
                                     <span class="score-title">Single Rating</span>

--- a/OngekiScoreLog/resources/views/user_progress.blade.php
+++ b/OngekiScoreLog/resources/views/user_progress.blade.php
@@ -164,6 +164,13 @@ $difficulties = ['Total', 'Basic', 'Advanced', 'Expert', 'Master', 'Lunatic'];
                                 <span class="score-title">Platinum Score</span>
                                 <span class="score">{{number_format($value['new']->platinum_score)}}</span>
                                 <span class="difference">{{$value['difference']['platinum_score']}}</span>
+                                {{-- new-normal-ratingが空=該当ユーザーがプレミアムでない 場合そもそもレーティング情報を表示しない --}}
+                                @if($isPremium)
+                                    <br>
+                                    <span class="score-title">Single Rating</span>
+                                    <span class="score">{{$value['difference']['new-normal-rating']}}</span>
+                                    <span class="difference">{{$value['difference']['normal_rating']}}</span>
+                                @endif
                             </div>
                             <div class="lamp-info">
                                 <span class="tag {{$value['difference']['old-lamp-is-fb']}}">FB</span>

--- a/OngekiScoreLog/resources/views/user_progress.blade.php
+++ b/OngekiScoreLog/resources/views/user_progress.blade.php
@@ -164,7 +164,6 @@ $difficulties = ['Total', 'Basic', 'Advanced', 'Expert', 'Master', 'Lunatic'];
                                 <span class="score-title">Platinum Score</span>
                                 <span class="score">{{number_format($value['new']->platinum_score)}}</span>
                                 <span class="difference">{{$value['difference']['platinum_score']}}</span>
-<<<<<<< HEAD
                                 {{-- 該当ユーザーがプレミアムでない場合そもそもレーティング情報を表示しない --}}
                                 @if($isPremium)
                                     <br>


### PR DESCRIPTION
## 内容
プレミアムコース未加入の場合でも更新差分のレート表示が行われていた問題の修正。
## 実装概要
未加入時、レート計算のスキップと表示のスキップを行い、v0.22.0以前のような表示にする。
## 結果
上記不具合の修正