### PR TITLE
fix: technical rankフィルタが理論値を無条件で弾く問題の修正

### DIFF
--- a/OngekiScoreLog/app/Http/Controllers/ViewUserProgressController.php
+++ b/OngekiScoreLog/app/Http/Controllers/ViewUserProgressController.php
@@ -216,7 +216,6 @@ class ViewUserProgressController extends Controller
                     if($value->battle_high_score !== 0){
                         // not implemented → played
                         // echo "[new] " . $value->title . " / " . $value->difficulty_str . "<br>";
-                        $newNormalRating = OngekiUtility::RateValueFromTitle($value->title, $value->difficulty, $value->technical_high_score, $value->lampForRating, $value->genre, $value->artist);
                         $progress[$music][$difficulty]["new"] = $value;
                         $progress[$music][$difficulty]["difference"]['battle_high_score'] = "+" . number_format($value->battle_high_score);
                         $progress[$music][$difficulty]["difference"]['technical_high_score'] = "+" . number_format($value->technical_high_score);
@@ -304,34 +303,8 @@ class ViewUserProgressController extends Controller
                             }
 
                             // Rating計算はできるだけ少なくしたいので先に計算しておく。
-                            // ViewUserRatingController.php から引用。
-                            // WARNING: レーティング処理を変えたら変更元も変更する！
                             if ($isPremium) {
-                                $oldLampForRating = "";
-                                if ($old[$music][$difficulty]->technical_high_score == 1010000){
-                                    if ($old[$music][$difficulty]->full_bell == 1) {
-                                        $oldLampForRating = "FB/AB+";
-                                    } else {
-                                        $oldLampForRating = "AB+";
-                                    }
-                                } elseif ($old[$music][$difficulty]->all_break == 1) {
-                                    if ($old[$music][$difficulty]->full_bell == 1) {
-                                        $oldLampForRating = "FB/AB";
-                                    } else {
-                                        $oldLampForRating = "AB";
-                                    }
-                                } elseif ($old[$music][$difficulty]->full_combo == 1) {
-                                    if ($old[$music][$difficulty]->full_bell == 1) {
-                                        $oldLampForRating = "FB/FC";
-                                    } else {
-                                        $oldLampForRating = "FC";
-                                    }
-                                } else {
-                                    if ($old[$music][$difficulty]->full_bell == 1) {
-                                        $oldLampForRating = "FB";
-                                    }
-                                }
-
+                                $oldLampForRating = OngekiUtility::getLampForRating($old[$music][$difficulty]->technical_high_score, $old[$music][$difficulty]->full_bell == 1, $old[$music][$difficulty]->full_combo == 1, $old[$music][$difficulty]->all_break == 1);
                                 $newNormalRating = OngekiUtility::RateValueFromTitle($value->title, $value->difficulty, $value->technical_high_score, $value->lampForRating, $value->genre, $value->artist);
                                 $oldNormalRating = OngekiUtility::RateValueFromTitle($value->title, $old[$music][$difficulty]->difficulty, $old[$music][$difficulty]->technical_high_score, $oldLampForRating, $value->genre, $value->artist);
                                 $progress[$music][$difficulty]["difference"]['normal_rating'] = ($newNormalRating - $oldNormalRating) != 0 ? "+" . sprintf("%.3f",($newNormalRating - $oldNormalRating)) : "";

--- a/OngekiScoreLog/app/Http/Controllers/ViewUserRatingController.php
+++ b/OngekiScoreLog/app/Http/Controllers/ViewUserRatingController.php
@@ -25,31 +25,7 @@ class ViewUserRatingController extends Controller
         for ($index = 0; $index < count($scores); $index++) {
             if (isset($scores[$index])) {
                 // ランプ情報追加
-                // WARNING: OngekiScoreLog\app\Http\Controllers\ViewUserProgressController.php にてコピペで使用している！ 変更したらそっちも変更すること！
-                $scores[$index]->lampForRating = "";
-                if ($scores[$index]->technical_high_score == 1010000){
-                    if ($scores[$index]->full_bell == 1) {
-                        $scores[$index]->lampForRating = "FB/AB+";
-                    } else {
-                        $scores[$index]->lampForRating = "AB+";
-                    }
-                } elseif ($scores[$index]->all_break == 1) {
-                    if ($scores[$index]->full_bell == 1) {
-                        $scores[$index]->lampForRating = "FB/AB";
-                    } else {
-                        $scores[$index]->lampForRating = "AB";
-                    }
-                } elseif ($scores[$index]->full_combo == 1) {
-                    if ($scores[$index]->full_bell == 1) {
-                        $scores[$index]->lampForRating = "FB/FC";
-                    } else {
-                        $scores[$index]->lampForRating = "FC";
-                    }
-                } else {
-                    if ($scores[$index]->full_bell == 1) {
-                        $scores[$index]->lampForRating = "FB";
-                    }
-                }
+                $scores[$index]->lampForRating = OngekiUtility::getLampForRating($scores[$index]->technical_high_score, $scores[$index]->full_bell == 1, $scores[$index]->full_combo == 1, $scores[$index]->all_break == 1);
 
                 // 単極レート値の取得
                 $scores[$index]->ratingValue = sprintf("%.3f", OngekiUtility::RateValueFromTitle($scores[$index]->title, $scores[$index]->difficulty, $scores[$index]->technical_high_score, $scores[$index]->lampForRating, $scores[$index]->genre, $scores[$index]->artist));

--- a/OngekiScoreLog/app/Services/OngekiUtility.php
+++ b/OngekiScoreLog/app/Services/OngekiUtility.php
@@ -238,7 +238,7 @@ class OngekiUtility {
     public function getLampForRating(int $technicalScore, bool $fullBell, bool $fullCombo, bool $allBreak): string
     {
         if ($technicalScore == 1010000) {
-            if ($fullBell == 1) {
+            if ($fullBell) {
                 return "FB/AB+";
             } else {
                 return "AB+";

--- a/OngekiScoreLog/app/Services/OngekiUtility.php
+++ b/OngekiScoreLog/app/Services/OngekiUtility.php
@@ -235,6 +235,34 @@ class OngekiUtility {
         return $this->calcPlatinumRatingValue($this::$MusicList[$title][$difficulty], $platinuScore, $starCount);
     }
 
+    public function getLampForRating(int $technicalScore, bool $fullBell, bool $fullCombo, bool $allBreak): string
+    {
+        if ($technicalScore == 1010000) {
+            if ($fullBell == 1) {
+                return "FB/AB+";
+            } else {
+                return "AB+";
+            }
+        } elseif ($allBreak) {
+            if ($fullBell) {
+                return "FB/AB";
+            } else {
+                return "AB";
+            }
+        } elseif ($fullCombo) {
+            if ($fullBell) {
+                return "FB/FC";
+            } else {
+                return "FC";
+            }
+        } else {
+            if ($fullBell) {
+                return "FB";
+            }
+        }
+        return "";
+    }
+
     private function calcPlatinumRatingValue(float $extraLevel, int $platinumScore, int $starCount)
     {
         if($starCount > 5){

--- a/OngekiScoreLog/resources/views/layouts/components/user/song_filter.blade.php
+++ b/OngekiScoreLog/resources/views/layouts/components/user/song_filter.blade.php
@@ -64,7 +64,7 @@
                 <a class="button filter_technical_rank_button">SS</a>
                 <a class="button filter_technical_rank_button">SSS</a>
                 <a class="button filter_technical_rank_button">SSS+</a>
-                <a class="button filter_technical_rank_button">P</a>
+                <a class="button filter_technical_rank_button">AB+</a>
             </div>
 
             <div class="filter-content">


### PR DESCRIPTION
## 内容
1. Technical RankフィルタのPが正常に動作していなかった問題の修正  
2. #946 でDRYに違反していた箇所の修正
## 実装概要
<img width="592" height="101" alt="image" src="https://github.com/user-attachments/assets/7c7529d8-aa16-4850-b6bd-eb32342b6822" /><br>
のような形でフィルタを修正。

OngekiUtilityにgetLampForRatingを追加し、既存の同等処理を当該関数を使用して行うように変更
## 結果
fixes: #1019

## 備考
2に関して問題あれば e0663b14ed080b7ef6792322af8e5a3c7f270e45 と 075f77f8ab42ae2d4b12c8c2a86640564d162b14 をrevertしていただけるとありがたいです。